### PR TITLE
Add date string to backend state key

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+    "_extensions": ["jinja2_time.TimeExtension"],
     "full_name": "me",
     "email": "me@there.com",
     "project_name": "Terraform Cookiecutter",

--- a/{{ cookiecutter.project_slug }}/tf/dev/backend.tf
+++ b/{{ cookiecutter.project_slug }}/tf/dev/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket  = "{{ cookiecutter.backend_bucket_dev }}"
-    key     = "{{ cookiecutter.project_slug }}/{{ cookiecutter.environment_dev }}/tfstate"
+    key     = "{{ cookiecutter.project_slug }}-{% now 'utc', '%Y-%m-%d' %}/{{ cookiecutter.environment_dev }}/tfstate"
     region  = "{{ cookiecutter.aws_region_dev }}"
     profile = "{{ cookiecutter.aws_profile_dev }}"
   }

--- a/{{ cookiecutter.project_slug }}/tf/prod/backend.tf
+++ b/{{ cookiecutter.project_slug }}/tf/prod/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket  = "{{ cookiecutter.backend_bucket_prod }}"
-    key     = "{{ cookiecutter.project_slug }}/{{ cookiecutter.environment_prod }}/tfstate"
+    key     = "{{ cookiecutter.project_slug }}-{% now 'utc', '%Y-%m-%d' %}/{{ cookiecutter.environment_prod }}/tfstate"
     region  = "{{ cookiecutter.aws_region_prod }}"
     profile = "{{ cookiecutter.aws_profile_prod }}"
   }


### PR DESCRIPTION
## Related Tasks

None

## Depends on

None

## What

Add a date string into the Terraform state key

## Why

 Offered as a method of minimising name collisions in the event we have to re-organise repositories

## Concerns

None

## Notes

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
